### PR TITLE
change discord link

### DIFF
--- a/resources/js/Pages/Home/Partials/UsefulLinks.vue
+++ b/resources/js/Pages/Home/Partials/UsefulLinks.vue
@@ -77,7 +77,7 @@ export default {
     return {
       links: [
         {
-          href: 'https://discord.gg/goonstation',
+          href: 'https://discord.gg/zd8t6pY',
           icon: ionLogoDiscord,
           label: 'Discord',
         },


### PR DESCRIPTION
changed it to /goonstation13, but this is less vulnerable anyways if we lose sponsors or whatever they're called i hate discord