### PR TITLE
Change traitorTag class handling slightly to allow for custom styling

### DIFF
--- a/resources/js/Pages/Admin/Logs/Partials/LogEntry.vue
+++ b/resources/js/Pages/Admin/Logs/Partials/LogEntry.vue
@@ -91,7 +91,7 @@
   color: black;
 }
 
-:deep(.traitor-marker) {
+:deep(.traitorTag) {
   display: inline-block;
   border-radius: 3px;
   padding: 0 5px;
@@ -155,9 +155,6 @@ export default {
         <span class="dmg-brute" title="Burn">$5</span>
       </span>`
       )
-
-      const traitorRegex = /\[<span class='traitorTag'>T<\/span>\]/g
-      message = message.replaceAll(traitorRegex, '<span class="traitor-marker">T</span>')
 
       if (this.searchTerms.length) {
         const searchRegex = new RegExp(


### PR DESCRIPTION
Changes the class name for the logging traitor tag to match the one actually used in the logs and removes the regex used to convert between them.
This should allow custom styling to be preserved and enable https://github.com/goonstation/goonstation/commit/0a5912e86cb00aeed675039701bda20e3249a1a0 to be displayed on the web logs too.